### PR TITLE
[FaceIdentification] fix deallocation mismatch

### DIFF
--- a/FaceIdentification/src/blob.cpp
+++ b/FaceIdentification/src/blob.cpp
@@ -126,7 +126,7 @@ void Blob::Permute(int dim1, int dim2, int dim3, int dim4) {
   for (int i = 0; i < 4; ++ i)
     shape_[i] = tmp_shape[i];
   memcpy(dat, tmp, sizeof(float) * count_);
-  delete tmp;
+  delete[] tmp;
 }
 
 void Blob::Release() {


### PR DESCRIPTION
When we allocate an array using the new …[…] syntax, we should deallocate it using delete[]. In this case, we needed to change delete to delete[]. If we use the wrong form of delete to match our allocation with new, we have undefined behavior.