### PR TITLE
supported OSX 10.11

### DIFF
--- a/FaceAlignment/src/cfan.cpp
+++ b/FaceAlignment/src/cfan.cpp
@@ -33,6 +33,8 @@
 #include "cfan.h"
 #include <string.h>
 #include <algorithm>
+#include <math.h>
+#include <cstdlib>
 /** A constructor.
   *  Initialize basic parameters.
   */

--- a/FaceAlignment/src/sift.cpp
+++ b/FaceAlignment/src/sift.cpp
@@ -32,7 +32,7 @@
 
 #include "sift.h"
 #include <string.h>
-
+#include <cmath>
 #define pi 3.1415926
 double SIFT::delta_gauss_x[25] = 
 {0.0284161904936934,0.0260724940559495,0,-0.0260724940559495,-0.0284161904936934,
@@ -226,7 +226,7 @@ void SIFT::ConvImage(double* image_orientation, double* conv_im)
 
   for(int k = 0; k < param.patch_size; k++)
   {
-	  weight[k] = abs(k - double(param.patch_size - 1)/2)/(param.sample_pixel);
+	  weight[k] = fabs(k - double(param.patch_size - 1)/2)/(param.sample_pixel);
 
 	  if(weight[k] <= 1)
 		  weight[k] = 1 - weight[k];


### PR DESCRIPTION
this pr to solution some question `error: use of undeclared identifier 'abs'; did you mean 'fabs'?` of osx 10.11 platform.